### PR TITLE
argument completion for gateway subcommands

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -1,8 +1,11 @@
 package cmd
 
 import (
+	"encoding/json"
+	"io/ioutil"
 	"os"
 
+	"github.com/hichtakk/nsxctl/client"
 	c "github.com/hichtakk/nsxctl/client"
 	"github.com/hichtakk/nsxctl/config"
 	ac "github.com/hichtakk/nsxctl/nsxalb"
@@ -50,6 +53,26 @@ func newCmd() *cobra.Command {
 
 func GetCmdRoot() *cobra.Command {
 	return newCmd()
+}
+
+func Login() error {
+	file, _ := ioutil.ReadFile(configfile)
+	json.Unmarshal(file, &conf)
+	nsxtclient = client.NewNsxtClient(false, debug)
+
+	var site config.NsxTSite
+	var err error
+	if useSite != "" {
+		site, err = conf.NsxT.GetSite(useSite)
+	} else {
+		site, err = conf.NsxT.GetCurrentSite()
+	}
+	if err != nil {
+		return err
+	}
+	nsxtclient.BaseUrl = site.Endpoint
+	nsxtclient.Login(site.GetCredential())
+	return nil
 }
 
 /*

--- a/cmd/show.go
+++ b/cmd/show.go
@@ -1,12 +1,6 @@
 package cmd
 
 import (
-	"encoding/json"
-	"io/ioutil"
-	"log"
-
-	"github.com/hichtakk/nsxctl/client"
-	"github.com/hichtakk/nsxctl/config"
 	"github.com/spf13/cobra"
 )
 
@@ -16,21 +10,10 @@ func NewCmdShow() *cobra.Command {
 		Use:   "show",
 		Short: "Show resources",
 		PersistentPreRunE: func(c *cobra.Command, args []string) error {
-			file, _ := ioutil.ReadFile(configfile)
-			json.Unmarshal(file, &conf)
-			nsxtclient = client.NewNsxtClient(false, debug)
-			var site config.NsxTSite
-			var err error
-			if useSite != "" {
-				site, err = conf.NsxT.GetSite(useSite)
-			} else {
-				site, err = conf.NsxT.GetCurrentSite()
-			}
-			if err != nil {
-				log.Fatal(err)
-			}
-			nsxtclient.BaseUrl = site.Endpoint
-			return nil
+			return Login()
+		},
+		PersistentPostRun: func(c *cobra.Command, args []string) {
+			nsxtclient.Logout()
 		},
 	}
 	showCmd.AddCommand(

--- a/cmd/top.go
+++ b/cmd/top.go
@@ -1,12 +1,6 @@
 package cmd
 
 import (
-	"encoding/json"
-	"io/ioutil"
-	"log"
-
-	"github.com/hichtakk/nsxctl/client"
-	"github.com/hichtakk/nsxctl/config"
 	"github.com/spf13/cobra"
 )
 
@@ -16,21 +10,7 @@ func NewCmdTop() *cobra.Command {
 		Use:   "top",
 		Short: "monitor resources",
 		PersistentPreRunE: func(c *cobra.Command, args []string) error {
-			file, _ := ioutil.ReadFile(configfile)
-			json.Unmarshal(file, &conf)
-			nsxtclient = client.NewNsxtClient(false, debug)
-			var site config.NsxTSite
-			var err error
-			if useSite != "" {
-				site, err = conf.NsxT.GetSite(useSite)
-			} else {
-				site, err = conf.NsxT.GetCurrentSite()
-			}
-			if err != nil {
-				log.Fatal(err)
-			}
-			nsxtclient.BaseUrl = site.Endpoint
-			return nil
+			return Login()
 		},
 	}
 	topCmd.AddCommand(


### PR DESCRIPTION
This is experimental and a suggestion for auto-completion of arguments.
I hope you give it a try.

To complete arg with api results, such as Tier-0 Gateway name, we need to login to the site (NSX-T/ALB) before the completion process.
So I moved the login process to the first subcommand (show, top, etc.) so that the ValidArgsFunction of these subcommands can get the api results to complete.
Also, this eliminates the need for subcommand login/logout in PreRun/PostRun.