### PR TITLE
Fix edge subcommands

### DIFF
--- a/client/fabric.go
+++ b/client/fabric.go
@@ -256,7 +256,11 @@ func (c *NsxtClient) GetTransportNodeStatus(id string) string {
 	if res.Error != nil {
 		return ""
 	}
-	return res.Body.(map[string]interface{})["status"].(string)
+	status := res.Body.(map[string]interface{})["status"]
+	if status != nil {
+			return status.(string)
+	}
+	return "UNKNOWN"
 }
 
 func (c *NsxtClient) GetTransportNodeById(uuid string) *structs.TransportNode {

--- a/cmd/nsxt-fabric.go
+++ b/cmd/nsxt-fabric.go
@@ -265,7 +265,14 @@ func NewCmdCreateEdge() *cobra.Command {
 	edgeCmd.MarkFlagRequired("address")
 	edgeCmd.MarkFlagRequired("root_password")
 	edgeCmd.MarkFlagRequired("admin_password")
-
+	edgeCmd.RegisterFlagCompletionFunc("template", func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+		Login()
+		edge_names := []string{}
+		for _, e := range nsxtclient.GetEdge() {
+			edge_names = append(edge_names, e.Name)
+		}
+		return edge_names, cobra.ShellCompDirectiveNoFileComp
+	})
 	return edgeCmd
 }
 

--- a/structs/nsxt.go
+++ b/structs/nsxt.go
@@ -327,7 +327,7 @@ type TransportNode struct {
 	HostSwitchSpec         HostSwitchSpec         `json:"host_switch_spec"`
 	EdgeNodeDeploymentInfo EdgeNodeDeploymentInfo `json:"node_deployment_info"`
 	ResourceType           string                 `json:"resource_type"`
-	Tunnels                TransportNodeTunnels
+	Tunnels                TransportNodeTunnels   `json:",omitempty"`
 }
 
 type TransportNodeTunnels []TransportNodeTunnel


### PR DESCRIPTION
Avoid errors that occur when the edge state is unknown.
Add auto-completion to --template option.