### PR TITLE
fix show vs error when discovered networks is NA

### DIFF
--- a/structs/nsxalb.go
+++ b/structs/nsxalb.go
@@ -145,13 +145,19 @@ func (v *VirtualServiceInventory) Print(w *tabwriter.Writer, verbose bool) {
 		}
 
 		for _, n := range vip.PlacementNetworks {
-			network_names = append(network_names, strings.Split(n.NetworkRef, "#")[1])
+			if strings.Contains(n.NetworkRef, "#") {
+				network_names = append(network_names, strings.Split(n.NetworkRef, "#")[1])
+			}
 		}
 		for _, n := range vip.DiscoveredNetworks {
-			network_names = append(network_names, strings.Split(n.NetworkRef, "#")[1])
+			if strings.Contains(n.NetworkRef, "#") {
+				network_names = append(network_names, strings.Split(n.NetworkRef, "#")[1])
+			}
 		}
 		for _, n := range vip.IpamNetworks {
-			network_names = append(network_names, strings.Split(n.NetworkRef, "#")[1])
+			if strings.Contains(n.NetworkRef, "#") {
+				network_names = append(network_names, strings.Split(n.NetworkRef, "#")[1])
+			}
 		}
 		test := make(map[string]bool)
 		network_names_uniq := []string{}


### PR DESCRIPTION
"show vs" gets vs network name from network_ref in the result of the api "/api/virtualservice-inventory/?include_name=true" but returns NA if the networks are not set.